### PR TITLE
Dancer2::Plugin::LogReport: Use correct VERSION

### DIFF
--- a/lib/Dancer2/Plugin/LogReport.pm
+++ b/lib/Dancer2/Plugin/LogReport.pm
@@ -86,7 +86,7 @@ sub import
 {   my $class = shift;
 
      # Import Log::Report into the caller. Import options get passed through
-     my $level = $Dancer2::VERSION > 0.166001 ? '+1' : '+2';
+     my $level = $Dancer2::Plugin::VERSION > 0.166001 ? '+1' : '+2';
      Log::Report->import($level, @_, syntax => 'LONG');
  
      # Ensure the overridden import method is called (from Exporter::Tiny)


### PR DESCRIPTION
* import: Attempts to use $Dancer2::VERSION fail due to it not
  being visible to the module. Switch to $Dancer2::Plugin::VERSION
  which is visible (plus Dancer2::Plugin is also used).

Various tests (with Data::Dumper debugging added):

Without change:
```
$ perl -MDancer2::Plugin::LogReport
Use of uninitialized value $Dancer2::VERSION in numeric gt (>) at /usr/local/share/perl5/Dancer2/Plugin/LogReport.pm line 35.
$VAR1 = {
          'level' => '+2',
          'version' => undef
        };
```
Without change, but forced use of Dancer2:
```
$ perl -MDancer2 -MDancer2::Plugin::LogReport
$VAR1 = {
          'level' => '+1',
          'version' => '0.207000'
        };
```

Without change, but with `use Dancer2` in Dancer2::Plugin::LogReport:
```
$ perl -MDancer2::Plugin::LogReport
Subroutine import redefined at /usr/local/share/perl5/Dancer2/Plugin/LogReport.pm line 34.
$VAR1 = {
          'level' => '+1',
          'version' => '0.207000'
        };
```

With change:
```
$ perl -MDancer2::Plugin::LogReport
$VAR1 = {
          'level' => '+1',
          'version' => '0.207000'
        };
```