### PR TITLE
Fix stacktrace sent to browser with show_errors disabled

### DIFF
--- a/lib/Dancer2/Plugin/LogReport.pm
+++ b/lib/Dancer2/Plugin/LogReport.pm
@@ -117,7 +117,12 @@ on_plugin_import
             name => 'core.app.route_exception',
             code => sub {
                 my ($app, $error) = @_;
-                report 'PANIC' => $error;
+                # If there is no request object then we are in an early hook
+                # and Dancer will not handle an exception cleanly (which will
+                # result in a stacktrace to the browser, a potential security
+                # vulnerability). Therefore in this case do not raise as fatal.
+                my $is_fatal = $app->request ? 1 : 0;
+                report {is_fatal => $is_fatal}, 'PANIC' => $error;
             },
         ),
     );
@@ -159,19 +164,6 @@ on_plugin_import
     my $sm = $settings->{session_messages} // \@default_reasons;
     $session_messages{$_} = 1
         for ref $sm eq 'ARRAY' ? @$sm : $sm;
-
-    # In a production server, we don't want the end user seeing (unexpected)
-    # exception messages, for both security and usability. If we detect
-    # that this is a production server (show_errors is 0), then we change
-    # the specific error to a generic error, when displayed to the user.
-    # The message can be customised in the config file.
-    my $fatal_error_message = $settings->{fatal_error_message}
-       // "An unexpected error has occurred";
-
-    unless($dsl->app->config->{show_errors})
-    {   $hide_real_message->{$_} = $fatal_error_message
-            for qw/FAULT ALERT FAILURE PANIC/;
-    }
 
     if(my $forward_template = $settings->{forward_template})
     {   # Add a route for the specified template
@@ -332,6 +324,18 @@ sub _message_add($)
     # for request(), which is used to access the cookies of a session.
     return unless $app->request;
 
+    # In a production server, we don't want the end user seeing (unexpected)
+    # exception messages, for both security and usability. If we detect
+    # that this is a production server (show_errors is 0), then we change
+    # the specific error to a generic error, when displayed to the user.
+    # The message can be customised in the config file.
+    # We evaluate this each message to allow show_errors to be set in the
+    # application (specifically makes testing a lot easier)
+    my $fatal_error_message = !$dsl->app->config->{show_errors}
+        && ($_settings->{fatal_error_message} // "An unexpected error has occurred");
+    $hide_real_message->{$_} = $fatal_error_message
+        for qw/FAULT ALERT FAILURE PANIC/;
+
     my $r = $msg->reason;
     if(my $newm = $hide_real_message->{$r})
     {   $msg    = __$newm;
@@ -343,7 +347,7 @@ sub _message_add($)
     push @$msgs, $msg;
     $session->write($messages_variable => $msgs);
 
-    return $dsl;
+    return ($dsl || undef, $msg);
 }
 
 #------
@@ -379,14 +383,20 @@ the session hooks, in which case recursive loops can be experienced.
 =cut
 
 sub _forward_home($)
-{   my $dsl = _message_add(shift) || _get_dsl();
+{   my ($dsl, $msg) = _message_add(shift);
+    $dsl ||= _get_dsl();
+
     my $page = $_settings->{forward_url} || '/';
 
-    # Don't forward if it's a GET request to the error page, as it will
-    # cause a recursive loop. In this case, do nothing, and let dancer
-    # handle it.
+    # Don't forward if it's a GET request to the error page, as it will cause a
+    # recursive loop. In this case, return the fatal error message as plain
+    # text to render that instead. If we can't do that because it's too early
+    # in the request, then let Dancer handle this with its default error
+    # handling
     my $req = $dsl->app->request or return;
-    return if $req->uri eq $page && $req->is_get;
+
+    $dsl->send_as(plain => "$msg")
+        if $req->uri eq $page && $req->is_get;
 
     $dsl->redirect($page);
 }


### PR DESCRIPTION
This commit prevents stacktraces being sent to the browser when show_errors is disabled, to prevent potential security vulnerabilities of knowing an application's internals.

- Firstly it checks whether the request object is available. If it is not, this is an indicator that the request is in the early stages (e.g.
in the before request hook). In this case, the exception raised will not be fatal as Dancer will not handle it cleanly.

- Secondly, rather than returning to Dancer and doing nothing under such circumstances, it now returns (as plain text) the default unexpected exception error text. If this can't be rendered (because it is too early in the request) then Dancer handles the exception cleanly with its default error handling.

In order to enable the testing of show_errors being enabled and disabled within one test file, this commit also evaluates that setting per message request rather than initialisation (at which point it is not possible to change it without reloading the module).