### PR TITLE
Avoid a "numeric" warning from Dancer2

### DIFF
--- a/lib/Dancer2/Plugin/LogReport.pm
+++ b/lib/Dancer2/Plugin/LogReport.pm
@@ -86,7 +86,10 @@ sub import
 {   my $class = shift;
 
      # Import Log::Report into the caller. Import options get passed through
-     my $level = $Dancer2::Plugin::VERSION > 0.166001 ? '+1' : '+2';
+     my $level = (
+         $Dancer2::Plugin::VERSION !~ /^0/
+         || $Dancer2::Plugin::VERSION > 0.166001
+     ) ? '+1' : '+2';
      Log::Report->import($level, @_, syntax => 'LONG');
  
      # Ensure the overridden import method is called (from Exporter::Tiny)


### PR DESCRIPTION
Dancer2 recently released version 1.0.0 in which its versioning scheme changed from a decimal, such as 0.400001 to non-numeric values.

This caused importing Dancer2::Plugin::LogReport to output the following warning:
Argument "1.0.0" isn't numeric in numeric gt (>) at ./lib/Dancer2/Plugin/LogReport.pm line 89.

This patch resolves this by only using a numeric comparison for version numbers beginning with a 0.  I assume no future release of Dancer2 will have such a version number.