### PR TITLE
test: Adapt to new Dancer2 numbering scheme

### DIFF
--- a/t/70dancer2.t
+++ b/t/70dancer2.t
@@ -1,6 +1,7 @@
 #!/usr/bin/env perl
 use strict;
 use warnings;
+use version;
 
 use Test::More;
 
@@ -10,7 +11,7 @@ BEGIN {
         if $@;
 
     plan skip_all => "Dancer2 is too old: $Dancer2::VERSION"
-        if $Dancer2::VERSION <= 0.166001;   # for to_app()
+        if version->parse($Dancer2::VERSION) <= 0.166001;   # for to_app()
 
     warn "Dancer2 version $Dancer2::VERSION\n";
 


### PR DESCRIPTION
A new Dancer2 version scheme broke a version comparison in tests:

    Argument "1.0.0" isn't numeric in numeric le (<=) at t/70dancer2.t line 12.
    Dancer2 version 1.0.0

This patch fixes the test in the same way as commit 210aa76fb7aeaa262484c02516f610b4f5c2ad57 did in a library.