### PR TITLE
Fix leak of server information to rendered web pages

### DIFF
--- a/lib/Dancer2/Plugin/LogReport.pm
+++ b/lib/Dancer2/Plugin/LogReport.pm
@@ -162,7 +162,7 @@ on_plugin_import
 				unless $app->request->var('_lr_panic_thrown');
 			},
 		),
-	);
+	) if version->parse($Dancer2::Plugin::VERSION) >= 2;
 
 	if($settings->{handle_http_errors})
 	{	# Need after_error for HTTP errors (eg 404) so as to

--- a/t/70dancer2.t
+++ b/t/70dancer2.t
@@ -178,6 +178,9 @@ subtest 'Throw error' => sub {
 # Tests to check unexpected exceptions
 subtest 'Unexpected exception default page' => sub {
 
+    plan skip_all => "Dancer2 v2.0 needed for handling exceptions in hooks"
+        if version->parse($Dancer2::VERSION) < 2;
+
     # An exception generated from the default route which cannot redirect to
     # the default route, so it throws a plain text error
     {


### PR DESCRIPTION
This makes the capture of unexpected errors more robust, ensuring that they do not cause undesired rendering to the webpage in production. Currently error messages such as the following are possible when there is an exception in a hook:

```
Exception caught in 'core.app.after_request' filter: Hook error: Can't call method "bar" on an undefined value at...
```
Before this PR is merged, it requires https://github.com/PerlDancer/Dancer2/pull/1738 and https://github.com/PerlDancer/Dancer2/pull/1739 to be released.